### PR TITLE
fix：修复for in循环能遍历到pipeline的问题

### DIFF
--- a/src/utils/ofd/pipeline.js
+++ b/src/utils/ofd/pipeline.js
@@ -18,7 +18,9 @@ Array.prototype.pipeline = async function(callback){
   }
   return value;
 };
-
+Object.defineProperty(Array.prototype, 'pipeline', {
+  enumerable: false
+});
 let _pipeline = function(...funcs){
   return funcs.pipeline((a, b) => b.call(this, a));
 }


### PR DESCRIPTION
安装插件后，发现Array原型上多了一个可枚举的属性 pipeline，排查后期望在这里该属性设置为不可枚举，希望可以被采纳